### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -2,6 +2,9 @@ name: CI Docker Compose
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MixKlim/happymeter/security/code-scanning/1](https://github.com/MixKlim/happymeter/security/code-scanning/1)

To fix the problem, explicitly declare a `permissions` block limiting the `GITHUB_TOKEN` to the minimal required scope. This workflow only needs to read repository contents for `actions/checkout`, so `contents: read` is sufficient. We can set this at the top (root) of the workflow so it applies to all jobs, without changing any job steps.

Concretely, in `.github/workflows/compose.yml`, add a `permissions` section after the `on:` declaration and before `jobs:`:

- Root level:
  - `permissions:`
    - `contents: read`

No imports or additional methods are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
